### PR TITLE
Jef OnPremises Group Writeback Cmdlets

### DIFF
--- a/src/Get-MsIdGroupWritebackConfiguration.ps1
+++ b/src/Get-MsIdGroupWritebackConfiguration.ps1
@@ -1,0 +1,137 @@
+<#
+.SYNOPSIS
+    Gets the group writeback configuration for the group ID
+    
+.EXAMPLE
+    PS > Get-MsIdGroupWritebackConfiguration -GroupId <GroupId>
+
+    Get Group Writeback for Group ID
+
+.EXAMPLE
+    PS > Get-MsIdGroupWritebackConfiguration -Group <Group>
+
+    Get Group Writeback for Group
+
+#>
+function Get-MsIdGroupWritebackConfiguration {
+    [CmdletBinding(DefaultParameterSetName = 'ObjectId')]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'ObjectId', Position = 0, ValueFromPipeline = $true)]
+        [ValidateScript( {
+            try {
+                [System.Guid]::Parse($_) | Out-Null
+                $true
+            }
+            catch {
+                throw "$_ is not a valid ObjectID format. Valid value is a GUID format only."
+            }
+        })]
+        [string[]]
+        # Group Object ID
+        $GroupId,
+        # Group Object
+        [Parameter(Mandatory = $true, ParameterSetName = 'GraphGroup', Position = 0, ValueFromPipeline = $true)]
+        [psobject[]] $Group
+    )
+    
+    begin {
+
+        if ($null -eq (Get-MgContext)) {
+            Write-Error "$(Get-Date -f T) - Please Connect to MS Graph API with the Connect-MgGraph cmdlet from the Microsoft.Graph.Authentication module first before calling functions!" -ErrorAction Stop
+        }
+        else {
+            
+            
+            if ((Get-MgProfile).Name -ne "beta")
+            {
+                Write-Error "$(Get-Date -f T) - Please select the beta profile with 'Select-MgProfile -Name beta' to use this cmdlet" -ErrorAction Stop
+            }
+            
+            $GroupsModuleVersion = (get-command -Module Microsoft.Graph.Groups -Name "Get-MGGroup").Version
+
+            if ($GroupsModuleVersion.Major -le "1" -and $GroupsModuleVersion.Minor -lt '10')
+            {
+                Write-Error ("Microsoft.Graph.Groups Module 1.10 or Greater is not installed!  Pleas Update-Module to the latest version!") -ErrorAction Stop
+                
+            }
+
+        }
+        
+    }
+    
+    process {
+
+
+        foreach ($gid in $GroupId)
+        {
+            Write-Verbose ("Retrieving Group Writeback Settings for Group ID {0}" -f $gid)
+            $checkedGroup = [ordered]@{}
+            $mgGroup = $null
+            $mgGroup = Get-MgGroup -GroupId $gid
+            $checkedGroup.id = $mgGroup.Id
+            $checkedGroup.DisplayName = $mgGroup.DisplayName
+
+
+            $groupType = ($group.GroupTypes -contains 'Unified') ? 'M365' : 'Security'
+            $checkedGroup.Type = $groupType
+        
+            $writebackEnabled = $null
+
+            switch ($group.writebackConfiguration.isEnabled)
+            {
+                $true { $writebackEnabled = "TRUE"}
+                $false { $writebackEnabled = "FALSE"}
+                $null { $writebackEnabled = "NOTSET"}
+            }
+            
+            
+            if ($null -ne ($group.writebackConfiguration.onPremisesGroupType))
+            {
+                $WriteBackOnPremGroupType = $group.writebackConfiguration.onPremisesGroupType
+            }
+            else {
+                if ($checkedGroup.Type -eq 'M365')
+                {
+                $WriteBackOnPremGroupType = "universalDistributionGroup (M365 DEFAULT)"
+                }
+                else {
+                    $WriteBackOnPremGroupType = "universalSecurityGroup (Security DEFAULT)"
+                }
+            }
+
+            $checkedGroup.WriteBackEnabled = $writebackEnabled
+            $checkedGroup.WriteBackOnPremGroupType = $WriteBackOnPremGroupType
+
+            if ($checkedGroup.Type -eq 'M365')
+            {
+                if ($checkedGroup.WriteBackEnabled -ne $false)
+                {
+                    $checkedGroup.EffectiveWriteBack = ("Cloud M365 group will be writtenback onprem as {0} grouptype" -f $WriteBackOnPremGroupType)
+                }
+                else {
+                    $checkedGroup.EffectiveWriteBack = "Cloud M365 group will NOT be writtenback onprem"
+                }
+            }
+
+            if ($checkedGroup.Type -eq 'Security')
+            {
+                if ($checkedGroup.WriteBackEnabled -eq $true)
+                {
+                    $checkedGroup.EffectiveWriteBack = ("Cloud security group will be writtenback onprem as {0} grouptype" -f $WriteBackOnPremGroupType)
+                }
+                else {
+                    $checkedGroup.EffectiveWriteBack = "Cloud security will NOT be writtenback onprem"
+                }
+            }
+
+            Write-Output ([pscustomobject]$checkedGroup)
+
+
+        }
+    }
+    
+    
+    end {
+        
+    }
+}

--- a/src/Get-MsIdGroupWritebackConfiguration.ps1
+++ b/src/Get-MsIdGroupWritebackConfiguration.ps1
@@ -12,26 +12,45 @@
 
     Get Group Writeback for Group
 
+.NOTES
+    THIS CODE-SAMPLE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED 
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR 
+    FITNESS FOR A PARTICULAR PURPOSE.
+    This sample is not supported under any Microsoft standard support program or service. 
+    The script is provided AS IS without warranty of any kind. Microsoft further disclaims all
+    implied warranties including, without limitation, any implied warranties of merchantability
+    or of fitness for a particular purpose. The entire risk arising out of the use or performance
+    of the sample and documentation remains with you. In no event shall Microsoft, its authors,
+    or anyone else involved in the creation, production, or delivery of the script be liable for 
+    any damages whatsoever (including, without limitation, damages for loss of business profits, 
+    business interruption, loss of business information, or other pecuniary loss) arising out of 
+    the use of or inability to use the sample or documentation, even if Microsoft has been advised 
+    of the possibility of such damages, rising out of the use of or inability to use the sample script, 
+    even if Microsoft has been advised of the possibility of such damages.   
 #>
 function Get-MsIdGroupWritebackConfiguration {
     [CmdletBinding(DefaultParameterSetName = 'ObjectId')]
     param (
-        [Parameter(Mandatory = $true, ParameterSetName = 'ObjectId', Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ObjectId', Position = 0, ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            ValueFromRemainingArguments = $false)]
         [ValidateScript( {
-            try {
-                [System.Guid]::Parse($_) | Out-Null
-                $true
-            }
-            catch {
-                throw "$_ is not a valid ObjectID format. Valid value is a GUID format only."
-            }
-        })]
+                try {
+                    [System.Guid]::Parse($_) | Out-Null
+                    $true
+                }
+                catch {
+                    throw "$_ is not a valid ObjectID format. Valid value is a GUID format only."
+                }
+            })]
         [string[]]
         # Group Object ID
         $GroupId,
         # Group Object
-        [Parameter(Mandatory = $true, ParameterSetName = 'GraphGroup', Position = 0, ValueFromPipeline = $true)]
-        [psobject[]] $Group
+        [Parameter(Mandatory = $true, ParameterSetName = 'GraphGroup', Position = 1, ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            ValueFromRemainingArguments = $false)]
+        [Microsoft.Graph.PowerShell.Models.MicrosoftGraphGroup1[]] $Group
     )
     
     begin {
@@ -42,15 +61,13 @@ function Get-MsIdGroupWritebackConfiguration {
         else {
             
             
-            if ((Get-MgProfile).Name -ne "beta")
-            {
+            if ((Get-MgProfile).Name -ne "beta") {
                 Write-Error "$(Get-Date -f T) - Please select the beta profile with 'Select-MgProfile -Name beta' to use this cmdlet" -ErrorAction Stop
             }
             
-            $GroupsModuleVersion = (get-command -Module Microsoft.Graph.Groups -Name "Get-MGGroup").Version
+            $GroupsModuleVersion = (Get-Command -Module Microsoft.Graph.Groups -Name "Get-MGGroup").Version
 
-            if ($GroupsModuleVersion.Major -le "1" -and $GroupsModuleVersion.Minor -lt '10')
-            {
+            if ($GroupsModuleVersion.Major -le "1" -and $GroupsModuleVersion.Minor -lt '10') {
                 Write-Error ("Microsoft.Graph.Groups Module 1.10 or Greater is not installed!  Pleas Update-Module to the latest version!") -ErrorAction Stop
                 
             }
@@ -61,69 +78,100 @@ function Get-MsIdGroupWritebackConfiguration {
     
     process {
 
+        if ($null -ne $Group) {
+            $GroupId = $group.id
+        }
 
-        foreach ($gid in $GroupId)
-        {
+        foreach ($gid in $GroupId) {
             Write-Verbose ("Retrieving Group Writeback Settings for Group ID {0}" -f $gid)
             $checkedGroup = [ordered]@{}
             $mgGroup = $null
+            $cloudGroupType = $null
+
+
+            Write-Verbose ("Retrieving mgGroup for Group ID {0}" -f $gid)
             $mgGroup = Get-MgGroup -GroupId $gid
+            Write-Debug ($mgGroup | Select-Object -Property Id, DisplayName, GroupTypes, SecurityEnabled, OnPremisesSyncEnabled -Expand WritebackConfiguration | Select-Object -Property Id, DisplayName, GroupTypes, SecurityEnabled, OnPremisesSyncEnabled, IsEnabled, OnPremisesGroupType | Out-String)
+
             $checkedGroup.id = $mgGroup.Id
             $checkedGroup.DisplayName = $mgGroup.DisplayName
+            $checkedGroup.SourceOfAuthority = if ($mgGroup.OnPremisesSyncEnabled -eq $true) { "On-Premises" }else { "Cloud" }
 
 
-            $groupType = ($group.GroupTypes -contains 'Unified') ? 'M365' : 'Security'
-            $checkedGroup.Type = $groupType
-        
-            $writebackEnabled = $null
-
-            switch ($group.writebackConfiguration.isEnabled)
-            {
-                $true { $writebackEnabled = "TRUE"}
-                $false { $writebackEnabled = "FALSE"}
-                $null { $writebackEnabled = "NOTSET"}
-            }
-            
-            
-            if ($null -ne ($group.writebackConfiguration.onPremisesGroupType))
-            {
-                $WriteBackOnPremGroupType = $group.writebackConfiguration.onPremisesGroupType
+            if ($mgGroup.GroupTypes -contains 'Unified') {
+                $cloudGroupType = "M365"
             }
             else {
-                if ($checkedGroup.Type -eq 'M365')
-                {
-                $WriteBackOnPremGroupType = "universalDistributionGroup (M365 DEFAULT)"
+                
+                if ($mgGroup.SecurityEnabled -eq $true) {
+                    $cloudGroupType = "Security"
                 }
                 else {
-                    $WriteBackOnPremGroupType = "universalSecurityGroup (Security DEFAULT)"
+                    $cloudGroupType = "Distribution"
                 }
             }
 
-            $checkedGroup.WriteBackEnabled = $writebackEnabled
-            $checkedGroup.WriteBackOnPremGroupType = $WriteBackOnPremGroupType
+            
+            $checkedGroup.Type = $cloudGroupType
 
-            if ($checkedGroup.Type -eq 'M365')
-            {
-                if ($checkedGroup.WriteBackEnabled -ne $false)
-                {
-                    $checkedGroup.EffectiveWriteBack = ("Cloud M365 group will be writtenback onprem as {0} grouptype" -f $WriteBackOnPremGroupType)
+            if ($checkedGroup.SourceOfAuthority -eq 'On-Premises') {
+                $checkedGroup.WriteBackEnabled = "N/A"
+                $checkedGroup.WriteBackOnPremGroupType = "N/A"
+                $checkedGroup.EffectiveWriteBack = "On-Premises is Source Of Authority for Group"
+            }
+            else {
+            
+                if ($checkedGroup.Type -eq 'Distribution') {
+                    $checkedGroup.WriteBackEnabled = "N/A"
+                    $checkedGroup.WriteBackOnPremGroupType = "N/A"
+                    $checkedGroup.EffectiveWriteBack = "Cloud Distribution Groups are not supported for group writeback to on-premises. Use M365 groups instead."
                 }
                 else {
-                    $checkedGroup.EffectiveWriteBack = "Cloud M365 group will NOT be writtenback onprem"
+                   
+        
+                    $writebackEnabled = $null
+
+                    switch ($mgGroup.writebackConfiguration.isEnabled) {
+                        $true { $writebackEnabled = "TRUE" }
+                        $false { $writebackEnabled = "FALSE" }
+                        $null { $writebackEnabled = "NOTSET" }
+                    }
+            
+            
+                    if ($null -ne ($mgGroup.writebackConfiguration.onPremisesGroupType)) {
+                        $WriteBackOnPremGroupType = $mgGroup.writebackConfiguration.onPremisesGroupType
+                    }
+                    else {
+                        if ($checkedGroup.Type -eq 'M365') {
+                            $WriteBackOnPremGroupType = "universalDistributionGroup (M365 DEFAULT)"
+                        }
+                        else {
+                            $WriteBackOnPremGroupType = "universalSecurityGroup (Security DEFAULT)"
+                        }
+                    }
+
+                    $checkedGroup.WriteBackEnabled = $writebackEnabled
+                    $checkedGroup.WriteBackOnPremGroupType = $WriteBackOnPremGroupType
+
+                    if ($checkedGroup.Type -eq 'M365') {
+                        if ($checkedGroup.WriteBackEnabled -ne $false) {
+                            $checkedGroup.EffectiveWriteBack = ("Cloud M365 group will be writtenback onprem as {0} grouptype" -f $WriteBackOnPremGroupType)
+                        }
+                        else {
+                            $checkedGroup.EffectiveWriteBack = "Cloud M365 group will NOT be writtenback on-premises"
+                        }
+                    }
+
+                    if ($checkedGroup.Type -eq 'Security') {
+                        if ($checkedGroup.WriteBackEnabled -eq $true) {
+                            $checkedGroup.EffectiveWriteBack = ("Cloud security group will be writtenback onprem as {0} grouptype" -f $WriteBackOnPremGroupType)
+                        }
+                        else {
+                            $checkedGroup.EffectiveWriteBack = "Cloud security will NOT be writtenback on-premises"
+                        }
+                    }
                 }
             }
-
-            if ($checkedGroup.Type -eq 'Security')
-            {
-                if ($checkedGroup.WriteBackEnabled -eq $true)
-                {
-                    $checkedGroup.EffectiveWriteBack = ("Cloud security group will be writtenback onprem as {0} grouptype" -f $WriteBackOnPremGroupType)
-                }
-                else {
-                    $checkedGroup.EffectiveWriteBack = "Cloud security will NOT be writtenback onprem"
-                }
-            }
-
             Write-Output ([pscustomobject]$checkedGroup)
 
 

--- a/src/Get-MsIdGroupWritebackConfiguration.ps1
+++ b/src/Get-MsIdGroupWritebackConfiguration.ps1
@@ -11,10 +11,7 @@
     PS > Get-MsIdGroupWritebackConfiguration -Group <Group>
 
     Get Group Writeback for Group
-.EXAMPLE
-    PS > Get-mggroup -filter "groupTypes/any(c:c eq 'Unified')"|Update-MsIdGroupWritebackConfiguration -WriteBackEnabled $false -verbose
 
-    For all M365 Groups in the tenant, set the WritebackEnabled to false to prevent them from being written back on-premises
 
 .NOTES
     THIS CODE-SAMPLE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED 
@@ -54,7 +51,7 @@ function Get-MsIdGroupWritebackConfiguration {
         [Parameter(Mandatory = $true, ParameterSetName = 'GraphGroup', Position = 1, ValueFromPipeline = $true,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
-        [Microsoft.Graph.PowerShell.Models.MicrosoftGraphGroup1[]] $Group
+        [Object[]] $Group
     )
     
     begin {

--- a/src/Get-MsIdGroupWritebackConfiguration.ps1
+++ b/src/Get-MsIdGroupWritebackConfiguration.ps1
@@ -32,9 +32,8 @@
 function Get-MsIdGroupWritebackConfiguration {
     [CmdletBinding(DefaultParameterSetName = 'ObjectId')]
     param (
-        [Parameter(Mandatory = $true, ParameterSetName = 'ObjectId', Position = 0, ValueFromPipeline = $true,
-            ValueFromPipelineByPropertyName = $true,
-            ValueFromRemainingArguments = $false)]
+        # Group Object ID
+        [Parameter(Mandatory = $true, ParameterSetName = 'ObjectId', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [ValidateScript( {
                 try {
                     [System.Guid]::Parse($_) | Out-Null
@@ -44,40 +43,44 @@ function Get-MsIdGroupWritebackConfiguration {
                     throw "$_ is not a valid ObjectID format. Valid value is a GUID format only."
                 }
             })]
-        [string[]]
-        # Group Object ID
-        $GroupId,
+        [string[]] $GroupId,
+        
         # Group Object
-        [Parameter(Mandatory = $true, ParameterSetName = 'GraphGroup', Position = 1, ValueFromPipeline = $true,
-            ValueFromPipelineByPropertyName = $true,
-            ValueFromRemainingArguments = $false)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'GraphGroup', Position = 1, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [Object[]] $Group
     )
     
     begin {
+        ## Initialize Critical Dependencies
+        $CriticalError = $null
+        try {
+            ## Import Required Modules
+            Import-Module Microsoft.Graph.Groups -MinimumVersion 1.10.0 -ErrorAction Stop
 
-        if ($null -eq (Get-MgContext)) {
-            Write-Error "$(Get-Date -f T) - Please Connect to MS Graph API with the Connect-MgGraph cmdlet from the Microsoft.Graph.Authentication module first before calling functions!" -ErrorAction Stop
-        }
-        else {
-            
-            
-            if ((Get-MgProfile).Name -ne "beta") {
-                Write-Error "$(Get-Date -f T) - Please select the beta profile with 'Select-MgProfile -Name beta' to use this cmdlet" -ErrorAction Stop
+            ## Check MgModule Connection
+            $MgContext = Get-MgContext
+            if ($MgContext) {
+                ## Check MgModule Consented Scopes
+                $MgPermissions = Find-MgGraphCommand -Command Get-MgGroup -ApiVersion beta | Select-Object -First 1 -ExpandProperty Permissions
+                if (!(Compare-Object $MgPermissions.Name -DifferenceObject $MgContext.Scopes -ExcludeDifferent)) {
+                    Write-Error "Additional scope needed, call Connect-MgGraph with one of the following scopes: $($MgPermissions.Name -join ', ')" -ErrorAction Stop
+                }
             }
-            
-            $GroupsModuleVersion = (Get-Command -Module Microsoft.Graph.Groups -Name "Get-MGGroup").Version
-
-            if ($GroupsModuleVersion.Major -le "1" -and $GroupsModuleVersion.Minor -lt '10') {
-                Write-Error ("Microsoft.Graph.Groups Module 1.10 or Greater is not installed!  Pleas Update-Module to the latest version!") -ErrorAction Stop
-                
+            else {
+                Write-Error "Authentication needed, call Connect-MgGraph." -ErrorAction Stop
             }
-
         }
+        catch { Write-Error -ErrorRecord $_ -ErrorVariable CriticalError; return }
         
+        ## Save Current MgProfile to Restore at End
+        $previousMgProfile = Get-MgProfile
+        if ($previousMgProfile.Name -ne 'beta') {
+            Select-MgProfile -Name 'beta'
+        }
     }
     
     process {
+        if ($CriticalError) { return }
 
         if ($null -ne $Group) {
             $GroupId = $group.id
@@ -141,7 +144,6 @@ function Get-MsIdGroupWritebackConfiguration {
 
                     }
                     Default {
-                   
         
                         $writebackEnabled = $null
 
@@ -189,12 +191,15 @@ function Get-MsIdGroupWritebackConfiguration {
             }
             Write-Output ([pscustomobject]$checkedGroup)
 
-
         }
     }
     
-    
     end {
-        
+        if ($CriticalError) { return }
+
+        ## Restore Previous MgProfile
+        if ($previousMgProfile -and $previousMgProfile.Name -ne (Get-MgProfile).Name) {
+            Select-MgProfile -Name $previousMgProfile.Name
+        }
     }
 }

--- a/src/MSIdentityTools.psd1
+++ b/src/MSIdentityTools.psd1
@@ -49,7 +49,7 @@
     #ProcessorArchitecture = ''
 
     # Modules that must be imported into the global environment prior to importing this module
-    RequiredModules = @(
+    RequiredModules      = @(
         @{ ModuleName = 'Microsoft.Graph.Authentication'; Guid = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; ModuleVersion = '1.9.2' }
     )
 
@@ -63,7 +63,7 @@
     # TypesToProcess = @()
 
     # Format files (.ps1xml) to be loaded when importing this module
-    FormatsToProcess = @('.\internal\SamlMessages.format.ps1xml')
+    FormatsToProcess     = @('.\internal\SamlMessages.format.ps1xml')
 
     # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
     NestedModules        = @(
@@ -119,6 +119,8 @@
         '.\Update-MsIdApplicationSigningKeyThumbprint.ps1'
         '.\Get-MsIdIsViralUser.ps1'
         '.\Get-MsIdHasMicrosoftAccount.ps1'
+        '.\Get-MsIdGroupWritebackConfiguration.ps1'
+        '.\Update-MsIdGroupWritebackConfiguration.ps1'
     )
 
     # Functions to export from this module
@@ -151,6 +153,8 @@
         'Update-MsIdApplicationSigningKeyThumbprint'
         'Get-MsIdIsViralUser'
         'Get-MsIdHasMicrosoftAccount'
+        'Get-MsIdGroupWritebackConfiguration'
+        'Update-MsIdGroupWritebackConfiguration'
     )
 
     # Cmdlets to export from this module

--- a/src/Update-MsIdGroupWritebackConfiguration.ps1
+++ b/src/Update-MsIdGroupWritebackConfiguration.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+    Update an Azure AD cloud group settings to writeback as an AD on-premises group
+    
+.EXAMPLE
+    PS > Update-MsIdGroupWritebackConfiguration -GroupId <GroupId> -WriteBackEnabled $false
+
+    Disable Group Writeback for Group ID
+
+.EXAMPLE
+    PS > Update-MsIdGroupWritebackConfiguration -GroupId <GroupId> -WriteBackEnabled $true -WriteBackOnPremGroupType universalDistributionGroup
+
+    Enable Group Writeback for Group ID as universalDistributionGroup on-premises
+.EXAMPLE
+    PS > Update-MsIdGroupWritebackConfiguration -GroupId <GroupId> -WriteBackEnabled $false
+
+    Disable Group Writeback for Group ID
+#>
+function Update-MsIdGroupWritebackConfiguration {
+    [CmdletBinding(DefaultParameterSetName = 'ObjectId')]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'ObjectId', Position = 0, ValueFromPipeline = $true)]
+        [string[]]
+        [ValidateScript( {
+            try {
+                [System.Guid]::Parse($_) | Out-Null
+                $true
+            }
+            catch {
+                throw "$_ is not a valid ObjectID format. Valid value is a GUID format only."
+            }
+        })]
+        [string[]]
+        #Group Object ID
+        $GroupId,
+        [bool]
+        $WriteBackEnabled,
+        [ValidateSet("universalDistributionGroup", "universalSecurityGroup", "universalMailEnabledSecurityGroup")]
+        [string]
+        $WriteBackOnPremGroupType
+    )
+    
+    begin {
+
+        if ($null -eq (Get-MgContext)) {
+            Write-Error "$(Get-Date -f T) - Please Connect to MS Graph API with the Connect-MgGraph cmdlet from the Microsoft.Graph.Authentication module first before calling functions!" -ErrorAction Stop
+        }
+        else {
+            
+            if (((Get-MgContext).Scopes -notcontains "Directory.ReadWrite.All") -and ((Get-MgContext).Scopes -notcontains "Group.ReadWrite.All"))
+            {
+                Write-Error "$(Get-Date -f T) - Please Connect to MS Graph API with the 'Connect-MgGraph -Scopes Group.ReadWrite.All' to include the Group.ReadWrite.All scope to update groups from MS Graph API." -ErrorAction Stop
+            }
+            
+            if ((Get-MgProfile).Name -ne "beta")
+            {
+                Write-Error "$(Get-Date -f T) - Please select the beta profile with 'Select-MgProfile -Name beta' to use this cmdlet" -ErrorAction Stop
+            }
+            
+            $GroupsModuleVersion = (get-command -Module Microsoft.Graph.Groups -Name "Get-MGGroup").Version
+            if ($GroupsModuleVersion.Major -le "1" -and $GroupsModuleVersion.Minor -lt '10')
+            {
+                Write-Error ("Microsoft.Graph.Groups Module 1.10 or Greater is not installed!  Pleas Update-Module to the latest version!") -ErrorAction Stop
+                
+            }
+
+        }
+        
+    }
+    
+    process {
+
+        foreach ($gid in $GroupId)
+        {
+
+            $group = Get-MgGroup -GroupId $gid
+
+            if ($group.GroupTypes -notcontains 'Unified')
+            {
+                if ($WriteBackOnPremGroupType -ne 'universalSecurityGroup')
+                {
+                    write-error ("{0} is not an M365 Group and can only be written back as a univeralSecurityGroup type!" -f $gid) -ErrorAction Stop
+                }
+            }
+
+
+            $wbc = @{}
+            $wbc.isEnabled = $WriteBackEnabled
+            $wbc.onPremisesGroupType = $WriteBackOnPremGroupType
+            Write-Verbose ("Updating Group {0} with Group Writeback settings of Writebackenabled={1} and onPremisesGroupType={2}" -f $gid,$WriteBackEnabled,$WriteBackOnPremGroupType )
+            Update-MgGroup -GroupId $gid -writeBackConfiguration $wbc
+            Write-Verbose ("Group Updated!")
+    }
+}
+    
+    end {
+        
+    }
+}

--- a/src/Update-MsIdGroupWritebackConfiguration.ps1
+++ b/src/Update-MsIdGroupWritebackConfiguration.ps1
@@ -15,26 +15,59 @@
     PS > Update-MsIdGroupWritebackConfiguration -GroupId <GroupId> -WriteBackEnabled $false
 
     Disable Group Writeback for Group ID
+.NOTES
+    - Updating Role Assignable Groups or Privileged Access Groups require PrivilegedAccess.ReadWrite.AzureADGroup permission scope
+
+    THIS CODE-SAMPLE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED 
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR 
+    FITNESS FOR A PARTICULAR PURPOSE.
+    This sample is not supported under any Microsoft standard support program or service. 
+    The script is provided AS IS without warranty of any kind. Microsoft further disclaims all
+    implied warranties including, without limitation, any implied warranties of merchantability
+    or of fitness for a particular purpose. The entire risk arising out of the use or performance
+    of the sample and documentation remains with you. In no event shall Microsoft, its authors,
+    or anyone else involved in the creation, production, or delivery of the script be liable for 
+    any damages whatsoever (including, without limitation, damages for loss of business profits, 
+    business interruption, loss of business information, or other pecuniary loss) arising out of 
+    the use of or inability to use the sample or documentation, even if Microsoft has been advised 
+    of the possibility of such damages, rising out of the use of or inability to use the sample script, 
+    even if Microsoft has been advised of the possibility of such damages.   
+
 #>
 function Update-MsIdGroupWritebackConfiguration {
     [CmdletBinding(DefaultParameterSetName = 'ObjectId')]
     param (
-        [Parameter(Mandatory = $true, ParameterSetName = 'ObjectId', Position = 0, ValueFromPipeline = $true)]
-        [string[]]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ObjectId', Position = 0, ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            ValueFromRemainingArguments = $false)]
         [ValidateScript( {
-            try {
-                [System.Guid]::Parse($_) | Out-Null
-                $true
-            }
-            catch {
-                throw "$_ is not a valid ObjectID format. Valid value is a GUID format only."
-            }
-        })]
+                try {
+                    [System.Guid]::Parse($_) | Out-Null
+                    $true
+                }
+                catch {
+                    throw "$_ is not a valid ObjectID format. Valid value is a GUID format only."
+                }
+            })]
         [string[]]
-        #Group Object ID
+        # Group Object ID
         $GroupId,
+        # Group Object
+        [Parameter(Mandatory = $true, ParameterSetName = 'GraphGroup', Position = 1, ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            ValueFromRemainingArguments = $false)]
+        [Microsoft.Graph.PowerShell.Models.MicrosoftGraphGroup1[]] 
+        $Group,
+        # WritebackEnabled true or false
+        [Parameter(Mandatory = $true, Position = 2, ValueFromPipeline = $false,
+            ValueFromPipelineByPropertyName = $false,
+            ValueFromRemainingArguments = $false)]
         [bool]
         $WriteBackEnabled,
+        [Parameter(Mandatory = $false, Position = 3, ValueFromPipeline = $false,
+            ValueFromPipelineByPropertyName = $false,
+            ValueFromRemainingArguments = $false)]
+        # On-Premises Group Type cloud group is written back as
         [ValidateSet("universalDistributionGroup", "universalSecurityGroup", "universalMailEnabledSecurityGroup")]
         [string]
         $WriteBackOnPremGroupType
@@ -47,19 +80,16 @@ function Update-MsIdGroupWritebackConfiguration {
         }
         else {
             
-            if (((Get-MgContext).Scopes -notcontains "Directory.ReadWrite.All") -and ((Get-MgContext).Scopes -notcontains "Group.ReadWrite.All"))
-            {
+            if (((Get-MgContext).Scopes -notcontains "Directory.ReadWrite.All") -and ((Get-MgContext).Scopes -notcontains "Group.ReadWrite.All")) {
                 Write-Error "$(Get-Date -f T) - Please Connect to MS Graph API with the 'Connect-MgGraph -Scopes Group.ReadWrite.All' to include the Group.ReadWrite.All scope to update groups from MS Graph API." -ErrorAction Stop
             }
             
-            if ((Get-MgProfile).Name -ne "beta")
-            {
+            if ((Get-MgProfile).Name -ne "beta") {
                 Write-Error "$(Get-Date -f T) - Please select the beta profile with 'Select-MgProfile -Name beta' to use this cmdlet" -ErrorAction Stop
             }
             
-            $GroupsModuleVersion = (get-command -Module Microsoft.Graph.Groups -Name "Get-MGGroup").Version
-            if ($GroupsModuleVersion.Major -le "1" -and $GroupsModuleVersion.Minor -lt '10')
-            {
+            $GroupsModuleVersion = (Get-Command -Module Microsoft.Graph.Groups -Name "Get-MGGroup").Version
+            if ($GroupsModuleVersion.Major -le "1" -and $GroupsModuleVersion.Minor -lt '10') {
                 Write-Error ("Microsoft.Graph.Groups Module 1.10 or Greater is not installed!  Pleas Update-Module to the latest version!") -ErrorAction Stop
                 
             }
@@ -70,28 +100,144 @@ function Update-MsIdGroupWritebackConfiguration {
     
     process {
 
-        foreach ($gid in $GroupId)
-        {
+        if ($null -ne $Group) {
+            $GroupId = $group.id
+        }
 
-            $group = Get-MgGroup -GroupId $gid
+        foreach ($gid in $GroupId) {
+            $currentIsEnabled = $null
+            $currentOnPremGroupType = $null
+            $mgGroup = $null
+            $groupSourceOfAuthority = $null
+            $wbc = @{}
+            $skipUpdate = $false
 
-            if ($group.GroupTypes -notcontains 'Unified')
-            {
-                if ($WriteBackOnPremGroupType -ne 'universalSecurityGroup')
-                {
-                    write-error ("{0} is not an M365 Group and can only be written back as a univeralSecurityGroup type!" -f $gid) -ErrorAction Stop
+            Write-Verbose ("Retrieving mgGroup for Group ID {0}" -f $gid)
+            $mgGroup = Get-MgGroup -GroupId $gid
+            Write-Debug ($mgGroup | Select-Object -Property Id, DisplayName, GroupTypes, SecurityEnabled, OnPremisesSyncEnabled -Expand WritebackConfiguration | Select-Object -Property Id, DisplayName, GroupTypes, SecurityEnabled, OnPremisesSyncEnabled, IsEnabled, OnPremisesGroupType | Out-String)
+
+            
+            $currentOnPremGroupType = $mgGroup.WritebackConfiguration.OnPremisesGroupType
+           
+            $currentIsEnabled = $mgGroup.WritebackConfiguration.IsEnabled
+            $cloudGroupType = $null
+            
+            if ($mggroup.GroupTypes -contains 'Unified') {
+                $cloudGroupType = "M365"
+            }
+            else {
+                
+                if ($mgGroup.SecurityEnabled -eq $true) {
+                    $cloudGroupType = "Security"
+                }
+                else {
+                    $cloudGroupType = "Distribution"
                 }
             }
 
+            $groupSourceOfAuthority = if ($mgGroup.OnPremisesSyncEnabled -eq $true) { "On-Premises" }else { "Cloud" }
 
-            $wbc = @{}
-            $wbc.isEnabled = $WriteBackEnabled
-            $wbc.onPremisesGroupType = $WriteBackOnPremGroupType
-            Write-Verbose ("Updating Group {0} with Group Writeback settings of Writebackenabled={1} and onPremisesGroupType={2}" -f $gid,$WriteBackEnabled,$WriteBackOnPremGroupType )
-            Update-MgGroup -GroupId $gid -writeBackConfiguration $wbc
-            Write-Verbose ("Group Updated!")
+
+
+            if ($groupSourceOfAuthority -eq 'On-Premises') {
+                $skipUpdate = $true
+                Write-Verbose ("Group {0} is an on-premises SOA group and will not be updated." -f $gid)
+            }
+            else {
+
+
+                switch ($cloudGroupType) {
+                    "Distribution" {
+                        $skipUpdate = $true
+                        Write-Error ("Group {0} is a cloud distribution group and will NOT be updated. Cloud Distribution Groups are not supported for group writeback to on-premises. Use M365 groups instead." -f $gid)
+
+                    }
+                    "Security" {
+
+
+                        Write-Verbose ("Group {0} is a Security Group with current IsEnabled of {1} and onPremisesGroupType of {2}." -f $gid, $currentIsEnabled, $currentOnPremGroupType)
+                       
+                        if ($currentIsEnabled -eq $WriteBackEnabled) {
+                            $skipUpdate = $true
+                            Write-Verbose "WriteBackEnabled $WriteBackEnabled already set for Security Group!"
+                        }
+                        else {
+
+                            $wbc.isEnabled = $WriteBackEnabled
+
+                            if ($null -eq $currentOnPremGroupType -or $currentOnPremGroupType -ne 'universalSecurityGroup') {
+                                if ($null -ne $WriteBackOnPremGroupType -and $WriteBackOnPremGroupType -ne 'universalSecurityGroup') {
+                                    $skipUpdate = $true
+                                    Write-Error ("{0} is not a cloud security group and can only be written back as a univeralSecurityGroup type which is not currently set for this group!" -f $gid)
+                            
+                                }
+                                else {
+                           
+                                    
+                                    if ($null -eq $currentOnPremGroupType -ne $WriteBackOnPremGroupType) {
+                                        $wbc.onPremisesGroupType = $WriteBackOnPremGroupType
+                                    }
+                                }
+                            }
+                    
+               
+                    
+                        }
+                    }
+
+                    "M365" {
+                         
+                        Write-Verbose ("Group {0} is an M365 Group with current IsEnabled of {1} and onPremisesGroupType of {2}." -f $gid, $currentIsEnabled, $currentOnPremGroupType)
+                        if ($currentIsEnabled -eq $WriteBackEnabled) {
+                            $skipUpdate = $true
+                            Write-Verbose "WriteBackEnabled $WriteBackEnabled already set for M365 Group!"
+                        }
+                        else {
+
+                            $wbc.isEnabled = $WriteBackEnabled
+
+                            if ($null -eq $currentOnPremGroupType -ne $WriteBackOnPremGroupType) {
+                                $wbc.onPremisesGroupType = $WriteBackOnPremGroupType
+                            }
+                    
+               
+                    
+                        }
+
+                    }
+
+            
+
+                
+            
+               
+          
+                }
+
+                if ($wbc.Count -eq 0) {
+                    $skipUpdate = $true
+                }
+
+                if ($skipUpdate -ne $true) {
+                    Write-Debug ($wbc | Out-String)
+                    Write-Verbose ("Updating Group {0} with Group Writeback settings of Writebackenabled={1} and onPremisesGroupType={2}" -f $gid, $WriteBackEnabled, $WriteBackOnPremGroupType )
+                    Update-MgGroup -GroupId $gid -writeBackConfiguration $wbc -ErrorAction Stop
+                    Write-Verbose ("Group Updated!")
+                }
+                else {
+                
+                    Write-Verbose ("No effective updates to group applied!")
+                }
+           
+            
+           
+
+               
+            }
+        }
     }
-}
+
+    
     
     end {
         

--- a/src/Update-MsIdGroupWritebackConfiguration.ps1
+++ b/src/Update-MsIdGroupWritebackConfiguration.ps1
@@ -129,6 +129,10 @@ function Update-MsIdGroupWritebackConfiguration {
                 
                 if ($mgGroup.SecurityEnabled -eq $true) {
                     $cloudGroupType = "Security"
+
+                    if ($null -ne $mgGroup.ProxyAddresses) {
+                        $cloudGroupType = "Mail-Enabled Security" 
+                    }
                 }
                 else {
                     $cloudGroupType = "Distribution"
@@ -150,6 +154,11 @@ function Update-MsIdGroupWritebackConfiguration {
                     "Distribution" {
                         $skipUpdate = $true
                         Write-Error ("Group {0} is a cloud distribution group and will NOT be updated. Cloud Distribution Groups are not supported for group writeback to on-premises. Use M365 groups instead." -f $gid)
+
+                    }
+                    "Mail-Enabled Security" {
+                        $skipUpdate = $true
+                        Write-Error ("Group {0} is a mail-enabled security group and will NOT be updated. Cloud mail-enabled security groups are not supported for group writeback to on-premises. Use M365 groups instead." -f $gid)
 
                     }
                     "Security" {

--- a/src/Update-MsIdGroupWritebackConfiguration.ps1
+++ b/src/Update-MsIdGroupWritebackConfiguration.ps1
@@ -60,7 +60,7 @@ function Update-MsIdGroupWritebackConfiguration {
         [Parameter(Mandatory = $true, ParameterSetName = 'GraphGroup', Position = 1, ValueFromPipeline = $true,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
-        [Microsoft.Graph.PowerShell.Models.MicrosoftGraphGroup1[]] 
+        [Object[]] 
         $Group,
         # WritebackEnabled true or false
         [Parameter(Mandatory = $true, Position = 2, ValueFromPipeline = $false,


### PR DESCRIPTION
Added 2 Cmdlets to allow enumerating and analyzing the writeback status of existing groups in the Azure AD tenant, and the ability to update the group writeback properties of groups.

This will allow tenant admins to review the current group properties that enable group writeback, and set the desired properties in bulk vs doing it manually in the Azure AD portal.