### PR TITLE
add Split-MsIdEntitlementManagementConnectedOrganization

### DIFF
--- a/src/MSIdentityTools.psd1
+++ b/src/MSIdentityTools.psd1
@@ -146,6 +146,7 @@
         '.\Get-MsIdAdfsSampleApp.ps1'
         '.\Get-MsIdInactiveSignInUser.ps1'
         '.\Set-MsIdServicePrincipalVisibleInMyApps.ps1'
+        '.\Split-MsIdEntitlementManagementConnectedOrganization.ps1'
     )
 
     # Functions to export from this module
@@ -199,6 +200,7 @@
         'Import-MsIdAdfsSamplePolicy'
         'Get-MsIdInactiveSignInUser'
         'Set-MsIdServicePrincipalVisibleInMyApps'
+        'Split-MsIdEntitlementManagementConnectedOrganization'
     )
 
     # Cmdlets to export from this module

--- a/src/Split-MsIdEntitlementManagementConnectedOrganization.ps1
+++ b/src/Split-MsIdEntitlementManagementConnectedOrganization.ps1
@@ -1,0 +1,55 @@
+<#
+.Synopsis
+Split elements of a connectedOrganization
+.Description
+Split elements of one or more Azure AD entitlement management connected organizations, returned by Get-MgEntitlementManagementConnectedOrganization, to simplify reporting.
+.Inputs
+Microsoft.Graph.PowerShell.Models.MicrosoftGraphConnectedOrganization
+
+#>
+function Split-MsIdEntitlementManagementConnectedOrganization {
+[CmdletBinding(DefaultParameterSetName='SplitByIdentitySource', PositionalBinding=$false, ConfirmImpact='Medium')]
+param(
+
+    [Parameter(ValueFromPipeline=$true,ParameterSetName='SplitByIdentitySource')]
+    [Microsoft.Graph.PowerShell.Models.MicrosoftGraphConnectedOrganization[]]
+    # The connected organization.
+    ${ConnectedOrganization},
+
+    [Parameter(Mandatory=$true, ParameterSetName='SplitByIdentitySource')]
+    [switch]
+    ${ByIdentitySource}
+
+)
+
+begin {
+
+}
+
+process {
+    if ($ByIdentitySource) {
+
+        if ($null -ne $ConnectedOrganization.IdentitySources) {
+            foreach ($is in $ConnectedOrganization.IdentitySources) {
+                # identity sources, as an abstract class, does not have any properties
+
+                $aObj = [pscustomobject]@{
+                    ConnectedOrganizationId = $ConnectedOrganization.Id
+                }
+            
+                $addl = $is.AdditionalProperties
+                foreach ($k in $addl.Keys) {
+                    $isk = $k
+                    $aObj | Add-Member -MemberType NoteProperty -Name $isk -Value $addl[$k] -Force
+                }
+
+                write-output $aObj
+            }
+        }
+    }
+}
+
+end {
+
+}
+}

--- a/src/Split-MsIdEntitlementManagementConnectedOrganization.ps1
+++ b/src/Split-MsIdEntitlementManagementConnectedOrganization.ps1
@@ -6,6 +6,11 @@ Split elements of one or more Azure AD entitlement management connected organiza
 .Inputs
 Microsoft.Graph.PowerShell.Models.MicrosoftGraphConnectedOrganization
 
+.EXAMPLE
+    PS > Get-MgEntitlementManagementConnectedOrganization -All |  Split-MsIdEntitlementManagementConnectedOrganization -ByIdentitySource | ft ConnectedOrganizationId,tenantId,domainName
+
+    Display one row for each identity source in all the connected organizations with the tenant id or domain name of the identity source.
+
 #>
 function Split-MsIdEntitlementManagementConnectedOrganization {
 [CmdletBinding(DefaultParameterSetName='SplitByIdentitySource', PositionalBinding=$false, ConfirmImpact='Medium')]


### PR DESCRIPTION
### Changes proposed in this pull request

Get-MgEntitlementManagementConnectedOrganization returns the connected organizations, each of which contains an array of IdentitySources.  As an IdentitySource is a base type in Graph with no properties of its own, all of its properties are represented within the AdditionalProperties table.  This helper cmdlet restructures the output of Get-MgEntitlementManagementConnectedOrganization by having each connected organization be split into its component identity resources, with one object output per identity source.  This cmdlet was previously part of MSGraph PowerShell cmdlets for beta Graph as Split-MgBetaEntitlementManagementConnectedOrganization but was not made available for MSGraph PowerShell cmdlets for v1.0 Graph.


### Documentation
<!-- Ensure all necessary documentation has been added or updated. Replace [ ] with [x] when complete. -->
- [x] All exported commands have Synopsis, Parameter Descriptions, and at least one Example.

### Other links

- [previous beta cmdlet](https://github.com/microsoftgraph/msgraph-sdk-powershell/blob/dev/src/Identity.Governance/beta/custom/Split-MgBetaEntitlementManagementConnectedOrganization.ps1)

