### PR TITLE
Fix api version referenced

### DIFF
--- a/src/Get-MsIdCrossTenantAccessActivity.ps1
+++ b/src/Get-MsIdCrossTenantAccessActivity.ps1
@@ -177,7 +177,7 @@ function Get-MsIdCrossTenantAccessActivity {
     begin {
         ## Initialize Critical Dependencies
         $CriticalError = $null
-        if (!(Test-MgCommandPrerequisites 'Get-MgAuditLogSignIn' -MinimumVersion 2.8.0 -ErrorVariable CriticalError)) { return }
+        if (!(Test-MgCommandPrerequisites 'Get-MgBetaAuditLogSignIn' -MinimumVersion 2.8.0 -ErrorVariable CriticalError)) { return }
 
         #External Tenant ID check
 
@@ -212,7 +212,7 @@ function Get-MsIdCrossTenantAccessActivity {
                 Write-Verbose -Message "$(Get-Date -f T) - Access direction 'Outbound' selected"
                 Write-Verbose -Message "$(Get-Date -f T) - Outbound: getting sign-ins for local users accessing external tenant ID - $ExternalTenantId"
 
-                $SignIns = Get-MgAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and ResourceTenantId eq '{0}'" -f $ExternalTenantId) -All | Group-Object ResourceTenantID
+                $SignIns = Get-MgBetaAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and ResourceTenantId eq '{0}'" -f $ExternalTenantId) -All | Group-Object ResourceTenantID
 
             }
             else {
@@ -220,7 +220,7 @@ function Get-MsIdCrossTenantAccessActivity {
                 Write-Verbose -Message "$(Get-Date -f T) - Access direction 'Outbound' selected"
                 Write-Verbose -Message "$(Get-Date -f T) - Outbound: getting external tenant IDs accessed by local users"
 
-                $SignIns = Get-MgAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and ResourceTenantId ne '{0}'" -f (Get-MgContext).TenantId) -All | Group-Object ResourceTenantID
+                $SignIns = Get-MgBetaAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and ResourceTenantId ne '{0}'" -f (Get-MgContext).TenantId) -All | Group-Object ResourceTenantID
 
             }
 
@@ -232,7 +232,7 @@ function Get-MsIdCrossTenantAccessActivity {
                 Write-Verbose -Message "$(Get-Date -f T) - Access direction 'Inbound' selected"
                 Write-Verbose -Message "$(Get-Date -f T) - Inbound: getting sign-ins for users accessing local tenant from external tenant ID - $ExternalTenantId"
 
-                $SignIns = Get-MgAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and HomeTenantId eq '{0}' and TokenIssuerType eq 'AzureAD'" -f $ExternalTenantId) -All | Group-Object HomeTenantID
+                $SignIns = Get-MgBetaAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and HomeTenantId eq '{0}' and TokenIssuerType eq 'AzureAD'" -f $ExternalTenantId) -All | Group-Object HomeTenantID
 
             }
             else {
@@ -240,7 +240,7 @@ function Get-MsIdCrossTenantAccessActivity {
                 Write-Verbose -Message "$(Get-Date -f T) - Access direction 'Inbound' selected"
                 Write-Verbose -Message "$(Get-Date -f T) - Inbound: getting external tenant IDs for external users accessing local tenant"
 
-                $SignIns = Get-MgAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and HomeTenantId ne '{0}' and TokenIssuerType eq 'AzureAD'" -f (Get-MgContext).TenantId) -All | Group-Object HomeTenantID
+                $SignIns = Get-MgBetaAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and HomeTenantId ne '{0}' and TokenIssuerType eq 'AzureAD'" -f (Get-MgContext).TenantId) -All | Group-Object HomeTenantID
 
             }
 
@@ -252,12 +252,12 @@ function Get-MsIdCrossTenantAccessActivity {
                 Write-Verbose -Message "$(Get-Date -f T) - Default access direction 'Both'"
                 Write-Verbose -Message "$(Get-Date -f T) - Outbound: getting sign-ins for local users accessing external tenant ID - $ExternalTenantId"
 
-                $Outbound = Get-MgAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and ResourceTenantId eq '{0}'" -f $ExternalTenantId) -All | Group-Object ResourceTenantID
+                $Outbound = Get-MgBetaAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and ResourceTenantId eq '{0}'" -f $ExternalTenantId) -All | Group-Object ResourceTenantID
 
 
                 Write-Verbose -Message "$(Get-Date -f T) - Inbound: getting sign-ins for users accessing local tenant from external tenant ID - $ExternalTenantId"
 
-                $Inbound = Get-MgAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and HomeTenantId eq '{0}' and TokenIssuerType eq 'AzureAD'" -f $ExternalTenantId) -All | Group-Object HomeTenantID
+                $Inbound = Get-MgBetaAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and HomeTenantId eq '{0}' and TokenIssuerType eq 'AzureAD'" -f $ExternalTenantId) -All | Group-Object HomeTenantID
 
 
             }
@@ -266,12 +266,12 @@ function Get-MsIdCrossTenantAccessActivity {
                 Write-Verbose -Message "$(Get-Date -f T) - Default access direction 'Both'"
                 Write-Verbose -Message "$(Get-Date -f T) - Outbound: getting external tenant IDs accessed by local users"
 
-                $Outbound = Get-MgAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and ResourceTenantId ne '{0}'" -f (Get-MgContext).TenantId) -All | Group-Object ResourceTenantID
+                $Outbound = Get-MgBetaAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and ResourceTenantId ne '{0}'" -f (Get-MgContext).TenantId) -All | Group-Object ResourceTenantID
 
 
                 Write-Verbose -Message "$(Get-Date -f T) - Inbound: getting external tenant IDs for external users accessing local tenant"
 
-                $Inbound = Get-MgAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and HomeTenantId ne '{0}' and TokenIssuerType eq 'AzureAD'" -f (Get-MgContext).TenantId) -All | Group-Object HomeTenantID
+                $Inbound = Get-MgBetaAuditLogSignIn -Filter ("CrossTenantAccessType ne 'none' and HomeTenantId ne '{0}' and TokenIssuerType eq 'AzureAD'" -f (Get-MgContext).TenantId) -All | Group-Object HomeTenantID
 
 
 

--- a/src/internal/Test-MgCommandPrerequisites.ps1
+++ b/src/internal/Test-MgCommandPrerequisites.ps1
@@ -17,7 +17,7 @@ function Test-MgCommandPrerequisites {
         # The service API version.
         [Parameter(Mandatory = $false, Position = 2)]
         [ValidateSet('v1.0', 'beta')]
-        [string] $ApiVersion = 'v1.0',
+        [string] $ApiVersion = 'beta',
         # Specifies a minimum version.
         [Parameter(Mandatory = $false)]
         [version] $MinimumVersion,


### PR DESCRIPTION
Fixes #29 

### Changes proposed in this pull request
- Change referenced API version from `v1.0` to `beta`.
- Replace use of `MgAuditLogSignIn` with `MgBetaAuditLogSignIn`

### Testing
Switch the required version to `beta` in `Test-MgCommandPrerequisites.ps1` to avoid the error:
> 'Get-MgBetaAuditLogSignIn' is not a valid Microsoft Graph PowerShell command. Please check the name and try again.
InvalidOperation: C:\Users\MortenHenrichsen\source\repos\MSIdentityTools\src\internal\Test-MgCommandPrerequisites.ps1:50:13

### Documentation
Not sure what to document.
