### PR TITLE
Fixed typo in Export-MsIdAppConsentGrantReport.ps1 documentation

### DIFF
--- a/src/Export-MsIdAppConsentGrantReport.ps1
+++ b/src/Export-MsIdAppConsentGrantReport.ps1
@@ -8,7 +8,7 @@
 
 .EXAMPLE
     PS > Install-Module ImportExcel
-    PS > Connect-MgGragh -Scopes Directory.Read.All
+    PS > Connect-MgGraph -Scopes Directory.Read.All
     PS > Export-MsIdAppConsentGrantReport -ReportOutputType ExcelWorkbook -ExcelWorkbookPath .\report.xlsx
 
     Output a report in Excel format


### PR DESCRIPTION
Fixed typo in 'MgGragh' to 'MgGraph'

### Changes proposed in this pull request
- There is a typo the the example command in the cmdlet documentation.
- This PR corrects the typo.

### Testing

I have tested copying and pasting the correct command and it now works as it should.

### Documentation

Documentation is now correct.

### Other links

n/a