### PR TITLE
Remove References to Test-MgCommandPrerequisites -APIVersion beta / Get-MsIdInactiveSignInUser Fix Timespan Error when lastNonInteractiveSignInDateTime is NULL

### DIFF
--- a/src/Find-MsIdUnprotectedUsersWithAdminRoles.ps1
+++ b/src/Find-MsIdUnprotectedUsersWithAdminRoles.ps1
@@ -28,7 +28,7 @@ function Find-MsIdUnprotectedUsersWithAdminRoles {
     begin {
         ## Initialize Critical Dependencies
         $CriticalError = $null
-        if (!(Test-MgCommandPrerequisites 'Get-MgUser', 'Get-MgUserAuthenticationMethod', 'Get-MgGroupMember', 'Get-MgRoleManagementDirectoryRoleDefinition', 'Get-MgRoleManagementDirectoryRoleAssignmentSchedule', 'Get-MgRoleManagementDirectoryRoleEligibilitySchedule', 'Get-MgAuditLogSignIn' -ApiVersion beta -MinimumVersion 2.8.0 -RequireListPermissions -ErrorVariable CriticalError)) { return }
+        if (!(Test-MgCommandPrerequisites 'Get-MgUser', 'Get-MgUserAuthenticationMethod', 'Get-MgGroupMember', 'Get-MgRoleManagementDirectoryRoleDefinition', 'Get-MgRoleManagementDirectoryRoleAssignmentSchedule', 'Get-MgRoleManagementDirectoryRoleEligibilitySchedule', 'Get-MgAuditLogSignIn' -MinimumVersion 2.8.0 -RequireListPermissions -ErrorVariable CriticalError)) { return }
 
 
         if ($VerbosePreference -eq 'SilentlyContinue') {

--- a/src/Get-MsIdGroupWritebackConfiguration.ps1
+++ b/src/Get-MsIdGroupWritebackConfiguration.ps1
@@ -57,7 +57,7 @@ function Get-MsIdGroupWritebackConfiguration {
     begin {
         ## Initialize Critical Dependencies
         $CriticalError = $null
-        if (!(Test-MgCommandPrerequisites 'Get-MgGroup' -ApiVersion beta -MinimumVersion 2.8.0 -ErrorVariable CriticalError)) { return }
+        if (!(Test-MgCommandPrerequisites 'Get-MgGroup' -MinimumVersion 2.8.0 -ErrorVariable CriticalError)) { return }
     }
 
     process {

--- a/src/Get-MsIdInactiveSignInUser.ps1
+++ b/src/Get-MsIdInactiveSignInUser.ps1
@@ -90,10 +90,17 @@ function Get-MsIdInactiveSignInUser {
                 $checkedUser.LastSignInDateTime = $userObject.signInActivity.LastSignInDateTime
                 $checkedUser.LastSigninDaysAgo = (New-TimeSpan -Start $checkedUser.LastSignInDateTime -End (Get-Date)).Days
                 $checkedUser.lastSignInRequestId = $userObject.signInActivity.lastSignInRequestId
-                $checkedUser.lastNonInteractiveSignInDateTime = $userObject.signInActivity.lastNonInteractiveSignInDateTime
 
-                $checkedUser.LastNonInteractiveSigninDaysAgo = (New-TimeSpan -Start $checkedUser.lastNonInteractiveSignInDateTime -End (Get-Date)).Days
-                $checkedUser.lastNonInteractiveSignInRequestId = $userObject.signInActivity.lastNonInteractiveSignInRequestId
+                #lastNonInteractiveSignInDateTime is NULL
+                If ($null -eq $userObject.signInActivity.lastNonInteractiveSignInDateTime){
+                    $checkedUser.lastNonInteractiveSignInDateTime = "Unknown"
+                    $checkedUser.LastNonInteractiveSigninDaysAgo = "Unknown"
+
+                } else {
+                    $checkedUser.lastNonInteractiveSignInDateTime = $userObject.signInActivity.lastNonInteractiveSignInDateTime
+                    $checkedUser.LastNonInteractiveSigninDaysAgo = (New-TimeSpan -Start $checkedUser.lastNonInteractiveSignInDateTime -End (Get-Date)).Days
+                    $checkedUser.lastNonInteractiveSignInRequestId = $userObject.signInActivity.lastNonInteractiveSignInRequestId
+                }
             }
             If ($null -eq $userObject.CreatedDateTime) {
                 $checkedUser.CreatedDateTime = "Unknown"

--- a/src/Update-MsIdGroupWritebackConfiguration.ps1
+++ b/src/Update-MsIdGroupWritebackConfiguration.ps1
@@ -71,7 +71,7 @@ function Update-MsIdGroupWritebackConfiguration {
     begin {
         ## Initialize Critical Dependencies
         $CriticalError = $null
-        if (!(Test-MgCommandPrerequisites 'Get-MgGroup', 'Update-MgGroup' -ApiVersion beta -MinimumVersion 2.8.0 -ErrorVariable CriticalError)) { return }
+        if (!(Test-MgCommandPrerequisites 'Get-MgGroup', 'Update-MgGroup' -MinimumVersion 2.8.0 -ErrorVariable CriticalError)) { return }
     }
 
     process {

--- a/src/internal/Test-MgCommandPrerequisites.ps1
+++ b/src/internal/Test-MgCommandPrerequisites.ps1
@@ -16,7 +16,7 @@ function Test-MgCommandPrerequisites {
         [string[]] $Name,
         # The service API version.
         [Parameter(Mandatory = $false, Position = 2)]
-        [ValidateSet('v1.0', 'beta')]
+        [ValidateSet('v1.0')]
         [string] $ApiVersion = 'v1.0',
         # Specifies a minimum version.
         [Parameter(Mandatory = $false)]
@@ -49,7 +49,7 @@ function Test-MgCommandPrerequisites {
 
             
             if ($MgCommands.Count -gt 1) {
-                $MgCommand = $MgCommands[0]                
+                $MgCommand = $MgCommands[0]
                 ## Resolve from multiple results
                 [array] $MgCommandsWithPermissions = $MgCommands | Where-Object Permissions -NE $null
                 [array] $MgCommandsWithListPermissions = $MgCommandsWithPermissions | Where-Object URI -NotLike "*}"


### PR DESCRIPTION
### Changes proposed in this pull request
- Removed references that call Test-MgCommandPrerequisites with parameter -APIVersion beta 
  Reference: APIVersion Beta is not supported anymore: https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/2582
- Get-MsIdInactiveSignInUser.ps1: Fix Timespan Error when lastNonInteractiveSignInDateTime is NULL

### Testing
Manual Testing

### Documentation
- [X ] All exported commands have Synopsis, Parameter Descriptions, and at least one Example.
