### PR TITLE
Fix typo in Update-MsIdInvitedUserSponsorsFromInvitedBy.ps1

### DIFF
--- a/src/Update-MsIdInvitedUserSponsorsFromInvitedBy.ps1
+++ b/src/Update-MsIdInvitedUserSponsorsFromInvitedBy.ps1
@@ -45,7 +45,7 @@ function Update-MsIdInvitedUserSponsorsFromInvitedBy {
         $CriticalError = $null
         if (!(Test-MgCommandPrerequisites 'Get-Mguser', 'Update-Mguser' -MinimumVersion 2.8.0 -ErrorVariable CriticalError)) { return }
 
-        $guestFilter = "(CreationType eq 'Invitiation')"
+        $guestFilter = "(CreationType eq 'Invitation')"
 
     }
 


### PR DESCRIPTION
Changed 'Invitiation' to 'Invitation'.

<!-- Add any issue numbers fixed by this PR. If this only partially fixes the issue, remove the word "Fixes" above to keep the issue open. -->
#61 

### Changes proposed in this pull request
<!-- Required: Provide specifics about what the changes are and why you are proposing these changes. -->
- Fixes a typo that causes `Unsupported or invalid query filter` exception when running with the `-All` parameter.

### Testing
<!-- Describe any relevant testing that has been done. Were automated tests added? -->
I've tested the `Get-MgUser` call on its own with the invalid filter clause and confirmed the same exception is thrown. Correcting the spelling of "Invitation" causes the call to succeed.
