### PR TITLE
Ensure Test-Mgcommand prerequisites is v1.0 and beta compatible

### DIFF
--- a/src/Get-MsIdCrossTenantAccessActivity.ps1
+++ b/src/Get-MsIdCrossTenantAccessActivity.ps1
@@ -177,7 +177,7 @@ function Get-MsIdCrossTenantAccessActivity {
     begin {
         ## Initialize Critical Dependencies
         $CriticalError = $null
-        if (!(Test-MgCommandPrerequisites 'Get-MgBetaAuditLogSignIn' -MinimumVersion 2.8.0 -ErrorVariable CriticalError)) { return }
+        if (!(Test-MgCommandPrerequisites 'Get-MgBetaAuditLogSignIn' -ApiVersion beta -MinimumVersion 2.8.0 -ErrorVariable CriticalError)) { return }
 
         #External Tenant ID check
 

--- a/src/internal/Test-MgCommandPrerequisites.ps1
+++ b/src/internal/Test-MgCommandPrerequisites.ps1
@@ -15,9 +15,10 @@ function Test-MgCommandPrerequisites {
         [Alias('Command')]
         [string[]] $Name,
         # The service API version.
-        [Parameter(Mandatory = $false, Position = 2)]
-        [ValidateSet('v1.0')]
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, Position = 2)]
+        [ValidateSet('v1.0', 'beta')]
         [string] $ApiVersion = 'v1.0',
+         #Default value is 'v1.0' if not specified.
         # Specifies a minimum version.
         [Parameter(Mandatory = $false)]
         [version] $MinimumVersion,
@@ -45,8 +46,8 @@ function Test-MgCommandPrerequisites {
         ## Get Graph Command Details
         [hashtable] $MgCommandLookup = @{}
         foreach ($CommandName in $Name) {
-
-            [array] $MgCommands = Find-MgGraphCommand -Command $CommandName -ApiVersion $ApiVersion -ErrorAction Break
+            [array] $MgCommands = @()
+            $MgCommands = Find-MgGraphCommand -Command $CommandName -ApiVersion $ApiVersion -ErrorAction Break
 
             if ($MgCommands.Count -eq 1) {
                 $MgCommand = $MgCommands[0]
@@ -151,3 +152,5 @@ function Test-MgCommandPrerequisites {
         return $result
     }
 }
+
+#Test-MgCommandPrerequisites -Name "Get-MgBetaUser" -ApiVersion "beta"

--- a/tests/Test-MgCommandPrerequisites.tests.ps1
+++ b/tests/Test-MgCommandPrerequisites.tests.ps1
@@ -28,39 +28,71 @@ Describe 'Test-MgCommandPrerequisites' {
 
         ## Mock commands with external dependancies or unavailable commands
         Mock -ModuleName $PSModule.Name Get-MgContext { New-Object Microsoft.Graph.PowerShell.Authentication.AuthContext -Property @{ Scopes = @('email', 'openid', 'profile', 'User.Read', 'User.Read.All'); AppName = 'Microsoft Graph PowerShell'; PSHostVersion = $PSVersionTable['PSVersion'] } } -Verifiable
+
         Mock -ModuleName $PSModule.Name Find-MgGraphCommand { 
-            New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphCommand -Property @{
-                Command     = 'Get-MgUser'
-                Module      = 'Users'
-                APIVersion  = 'v1.0'
-                Method      = 'GET'
-                URI         = '/users'
-                Permissions = @(
-                    New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.Read.All'; IsAdmin = $true; Description = "Read all users' full profiles" }
-                    New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.ReadBasic.All'; IsAdmin = $false; Description = "Read all users' basic profiles" }
-                    New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.ReadWrite.All'; IsAdmin = $true; Description = "Read and write all users' full profiles" }
-                )
+            param ($Command, $ApiVersion)
+            if ($ApiVersion -eq 'v1.0') {
+                New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphCommand -Property @{
+                    Command     = 'Get-MgUser'
+                    Module      = 'Users'
+                    APIVersion  = 'v1.0'
+                    Method      = 'GET'
+                    URI         = '/users'
+                    Permissions = @(
+                        New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.Read.All'; IsAdmin = $true; Description = "Read all users' full profiles" }
+                        New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.ReadBasic.All'; IsAdmin = $false; Description = "Read all users' basic profiles" }
+                        New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.ReadWrite.All'; IsAdmin = $true; Description = "Read and write all users' full profiles" }
+                    )
+                }
+                New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphCommand -Property @{
+                    Command     = 'Get-MgUser'
+                    Module      = 'Users'
+                    APIVersion  = 'v1.0'
+                    Method      = 'GET'
+                    URI         = '/users/{user-id}'
+                    Permissions = @(
+                        New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.Read'; IsAdmin = $false; Description = "Sign you in and read your profile" }
+                        New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.ReadWrite'; IsAdmin = $false; Description = "Read and update your profile" }
+                        New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.Read.All'; IsAdmin = $true; Description = "Read all users' full profiles" }
+                    )
+                }
+
+            } elseif ($ApiVersion -eq 'beta') {
+                New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphCommand -Property @{
+                    Command     = 'Get-MgBetaUser'
+                    Module      = 'Users'
+                    APIVersion  = 'beta'
+                    Method      = 'GET'
+                    URI         = '/beta/users'
+                    Permissions = @(
+                        New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.Read.All'; IsAdmin = $true; Description = "Read all users' full profiles" }
+                        New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.ReadBasic.All'; IsAdmin = $false; Description = "Read all users' basic profiles" }
+                        New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.ReadWrite.All'; IsAdmin = $true; Description = "Read and write all users' full profiles" }
+                    )
+                }
+                New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphCommand -Property @{
+                    Command     = 'Get-MgBetaUser'
+                    Module      = 'Users'
+                    APIVersion  = 'beta'
+                    Method      = 'GET'
+                    URI         = '/beta/users/{user-id}'
+                    Permissions = @(
+                        New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.Read'; IsAdmin = $false; Description = "Sign you in and read your profile" }
+                        New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.ReadWrite'; IsAdmin = $false; Description = "Read and update your profile" }
+                        New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.Read.All'; IsAdmin = $true; Description = "Read all users' full profiles" }
+                    )
+                }
             }
-            New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphCommand -Property @{
-                Command     = 'Get-MgUser'
-                Module      = 'Users'
-                APIVersion  = 'v1.0'
-                Method      = 'GET'
-                URI         = '/users/{user-id}'
-                Permissions = @(
-                    New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.Read'; IsAdmin = $false; Description = "Sign you in and read your profile" }
-                    New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.ReadWrite'; IsAdmin = $false; Description = "Read and update your profile" }
-                    New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphPermission -Property @{ Name = 'User.Read.All'; IsAdmin = $true; Description = "Read all users' full profiles" }
-                )
-            }
-        } -ParameterFilter { $Command -eq 'Get-MgUser' } -Verifiable
+        } -ParameterFilter { $Command -eq 'Get-MgUser' -or $Command -eq 'Get-MgBetaUser' } -Verifiable
+
         Mock -ModuleName $PSModule.Name Import-Module { } -ParameterFilter { $Name -ne 'Microsoft.Graph.Authentication' } -Verifiable
 
         ## Test Cases
         $TestCases = @(
             @{ Name = 'Get-MgUser'; Expected = $true }
-            @{ Name = 'Get-MgUser'; ApiVersion = 'Beta'; Expected = $true }
-            @{ Name = 'Get-MgUser'; ApiVersion = 'Beta'; MinimumVersion = '1.0'; Expected = $true }
+            @{ Name = 'Get-MgUser'; ApiVersion = 'v1.0'; Expected = $true }
+            @{ Name = 'Get-MgUser'; ApiVersion = 'v1.0'; MinimumVersion = '1.0'; Expected = $true }
+            @{ Name = 'Get-MgBetaUser'; ApiVersion = 'Beta'; MinimumVersion = '2.8.0'; Expected = $true }
         )
     }
 
@@ -68,34 +100,43 @@ Describe 'Test-MgCommandPrerequisites' {
             @{ Name = 'Get-MgUser'; Expected = $true }
             @{ Name = 'Get-MgUser'; ApiVersion = 'V1.0'; Expected = $true }
             @{ Name = 'Get-MgUser'; ApiVersion = 'V1.0'; MinimumVersion = '1.0'; Expected = $true }
+            @{ Name = 'Get-MgBetaUser'; ApiVersion = 'Beta'; MinimumVersion = '1.0'; Expected = $true }
         ) {
         BeforeAll {
             InModuleScope $PSModule.Name -ArgumentList $_ {
                 $script:params = $args[0].Clone()
                 $script:params.Remove('Name')
                 $script:params.Remove('Expected')
+                
+
             }
         }
 
         It 'Positional Parameter' {
             InModuleScope $PSModule.Name -Parameters $_ {
-                $Output = Test-MgCommandPrerequisites $Name @params -ErrorVariable actualErrors
+                if ($script:params['ApiVersion']) {
+                    # Call Test-MgCommandPrerequisites with positional parameters
+                    $Output = Test-MgCommandPrerequisites -Name $Name -ApiVersion $ApiVersion -ErrorVariable actualErrors
+                } else {
+                    # Call Test-MgCommandPrerequisites without ApiVersion
+                    $Output = Test-MgCommandPrerequisites -Name $Name -ErrorVariable actualErrors
+                }
                 $Output | Should -BeOfType [bool]
                 $Output | Should -BeExactly $Expected
                 Should -Invoke Find-MgGraphCommand -ParameterFilter {
-                    $Command -eq $Name
+                    $Command -eq $Name -and $ApiVersion -eq $ApiVersion
                 }
                 $actualErrors | Should -HaveCount 0
             }
         }
-
+    
         It 'Pipeline Input' {
             InModuleScope $PSModule.Name -Parameters $_ {
                 $Output = $Name | Test-MgCommandPrerequisites @params -ErrorVariable actualErrors
                 $Output | Should -BeOfType [bool]
                 $Output | Should -BeExactly $Expected
                 Should -Invoke Find-MgGraphCommand -ParameterFilter {
-                    $Command -eq $Name
+                    $Command -eq $Name -and $ApiVersion -eq $ApiVersion
                 }
                 $actualErrors | Should -HaveCount 0
             }
@@ -106,7 +147,7 @@ Describe 'Test-MgCommandPrerequisites' {
         BeforeAll {
             Mock -ModuleName $PSModule.Name Find-MgGraphCommand { 
                 New-Object Microsoft.Graph.PowerShell.Authentication.Models.GraphCommand -Property @{
-                    Command     = 'Get-MgDirectoryObjectById'
+                    Command     = 'Get-MgUser'
                     Module      = 'Users'
                     APIVersion  = 'v1.0'
                     Method      = 'POST'
@@ -146,19 +187,48 @@ Describe 'Test-MgCommandPrerequisites' {
 
         It 'Positional Parameter' {
             InModuleScope $PSModule.Name -Parameters @{ TestCases = $TestCases } {
-                $Output = Test-MgCommandPrerequisites $TestCases.Name -ErrorVariable actualErrors
-                $Output | Should -BeOfType [bool]
-                $Output | Should -HaveCount 1  # Only pipeline will return multiple outputs
-                Should -Invoke Find-MgGraphCommand -Times 3 -ParameterFilter {
-                    $Command -in $TestCases.Name
+                foreach ($testCase in $TestCases) {
+                    # Provide default value for ApiVersion if not specified
+                    try {
+                        $apiVersion = $testCase.ApiVersion
+                    }
+                    catch {
+                        $apiVersion = 'v1.0'
+                    }
+                    # Call the function with positional parameters
+                    $Output = Test-MgCommandPrerequisites $testCase.Name $apiVersion -ErrorVariable actualErrors
+                    
+                    # Validate the output
+                    $Output | Should -BeOfType [bool]
+                    $Output | Should -HaveCount 1  # Only pipeline will return multiple outputs
+                    Should -Invoke Find-MgGraphCommand -Times 1 -ParameterFilter {
+                        $Command -in $testCase.Name
+                    }
+                    $actualErrors | Should -HaveCount 0
                 }
-                $actualErrors | Should -HaveCount 0
             }
         }
 
         It 'Pipeline Input' {
             InModuleScope $PSModule.Name -Parameters @{ TestCases = $TestCases } {
-                $Output = $TestCases.Name | Test-MgCommandPrerequisites -ErrorVariable actualErrors
+                # Create custom objects with Name and ApiVersion properties
+                $TestCasesWithApiVersion = foreach ($testCase in $TestCases) {
+                    try {
+                        $apiVersion = $testCase.ApiVersion
+                    }
+                    catch {
+                        $apiVersion = 'v1.0'
+                    }
+                    [PSCustomObject]@{
+                        Name       = $testCase.Name
+                        ApiVersion = $apiVersion
+                    }
+                }
+        
+                # Pipe the custom objects to the function
+                $Output = $TestCasesWithApiVersion | Test-MgCommandPrerequisites -ErrorVariable actualErrors
+        
+                # Validate the output
                 $Output | Should -BeOfType [bool]
                 $Output | Should -HaveCount $TestCases.Count
                 for ($i = 0; $i -lt $TestCases.Count; $i++) {


### PR DESCRIPTION
<!-- Add any issue numbers fixed by this PR. If this only partially fixes the issue, remove the word "Fixes" above to keep the issue open. -->
Fixes #70 

### Changes proposed in this pull request
<!-- Required: Provide specifics about what the changes are and why you are proposing these changes. -->
- Added Back and confirmed that Beta Commands are returned via Find-MgGraphCommand which is part of microsoft.graph.authentication v1.0 module  Beta uses this v1.0 module as well

### Testing
<!-- Describe any relevant testing that has been done. Were automated tests added? -->
Updated pester tests for Test-MgCommandPrerequisites
![image](https://github.com/user-attachments/assets/e1bf4cfb-89dc-40ba-8dfe-2e93b0cfee5c)


Tested the Get-MsIdCrossTenantAccessActivity command e2e manually
![image](https://github.com/user-attachments/assets/e3377fd6-902b-4ff1-af01-6a426b680fd8)


### Documentation
<!-- Ensure all necessary documentation has been added or updated. Replace [ ] with [x] when complete. -->
- [x] All exported commands have Synopsis, Parameter Descriptions, and at least one Example.

