### PR TITLE
Remove redundant 'click Apply' instruction

### DIFF
--- a/src/Export-MsIdAzureMfaReport.ps1
+++ b/src/Export-MsIdAzureMfaReport.ps1
@@ -71,7 +71,7 @@
     - Sign-in to the **[Entra Admin Portal](https://entra.microsoft.com)**
     - From the left navigation select: **Identity** → **Monitoring & health** → **Sign-in logs**.
     - Select the **Date** filter and set to **Last 7 days**
-    - Select **Add filters** → **Application** and click **Apply**
+    - Select **Add filters** → **Application**
     - Type in: **Azure** and click **Apply**
     - Select **Download** → **Download JSON**
     - Set the **File Name** of the first textbox to **signins** and click **Download**.


### PR DESCRIPTION
User need to click Apply after Typing in Azure

<!-- Add any issue numbers fixed by this PR. If this only partially fixes the issue, remove the word "Fixes" above to keep the issue open. -->
Fixes #

### Changes proposed in this pull request
<!-- Required: Provide specifics about what the changes are and why you are proposing these changes. -->
- Removed `click apply` after selecting application.
