### PR TITLE
Fix incorrect Graph permission name for cross-tenant access (in help text)

### DIFF
--- a/src/Get-MsIdCrossTenantAccessActivity.ps1
+++ b/src/Get-MsIdCrossTenantAccessActivity.ps1
@@ -22,7 +22,7 @@
 
     -Verbose will give insight into the cmdlets activities.
 
-    Requires AuditLog.Read.All scope (to access logs) and CrossTenantInfo.ReadBasic.All scope
+    Requires AuditLog.Read.All scope (to access logs) and CrossTenantInformation.ReadBasic.All scope
     (for -ResolveTenantId), i.e. Connect-MgGraph -Scopes AuditLog.Read.All
 
 


### PR DESCRIPTION
Corrected CrossTenantInfo.ReadBasic.All to CrossTenantInformation.ReadBasic.All in comment-based help and examples.

<!-- Add any issue numbers fixed by this PR. If this only partially fixes the issue, remove the word "Fixes" above to keep the issue open. -->
Fixes #

### Changes proposed in this pull request
<!-- Required: Provide specifics about what the changes are and why you are proposing these changes. -->
- "CrossTenantInfo.ReadBasic.All" does not exist (or has ever existed afaik) as a Graph scope
- The correct name of this scope is "CrossTenantInformation.ReadBasic.All"
-

### Testing
<!-- Describe any relevant testing that has been done. Were automated tests added? -->
Connect-MGGraph -scope CrossTenantInfo.ReadBasic.All
FAIL: Scope does not exist
Connect-MGGraph -scope CrossTenantInformation.ReadBasic.All
PASS

This change updates help text only; no runtime behavior is modified.

### Documentation
<!-- Ensure all necessary documentation has been added or updated. Replace [ ] with [x] when complete. -->
- [x] All exported commands have Synopsis, Parameter Descriptions, and at least one Example.
- Official MS documentation on this request: https://learn.microsoft.com/en-us/graph/permissions-reference#crosstenantinformationreadbasicall 
### Other links
<!-- Provide any related links such as other pull requests, code files, StackOverflow posts. Delete this section if not used. -->
-
-
-
